### PR TITLE
Fix GitHub release creation step

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -53,8 +53,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          output="$(gh release view ${SQLCHECK_PACKAGE_VERSION})"
-          if [[ $? -eq 0 ]] ; then
+          if gh release view ${SQLCHECK_PACKAGE_VERSION} 2>/dev/null; then
             echo Release for ${SQLCHECK_PACKAGE_VERSION} already exists
             echo ${output}
           else


### PR DESCRIPTION
If the release doesn't exist, the command exists non-zero, which causes the build to [fail][1] as
I'd forgotten that GitHub Actions runs shell commands with `set -e` 🤦‍♂️.

[1]: https://github.com/bitsoex/sqlcheck/runs/4866134268?check_suite_focus=true#step:7:16
