### PR TITLE
fix: Allow long lines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ enable_language(CXX)
 
 # ---[ C++ Flags
 if(CMAKE_CXX_COMPILER_ID MATCHES GNU)
-    set(CMAKE_CXX_FLAGS         "-Wall -Wno-unknown-pragmas -Wno-sign-compare -Woverloaded-virtual -Wno-write-strings")
+    set(CMAKE_CXX_FLAGS         "-Wall -Wno-unknown-pragmas -Wno-sign-compare -Woverloaded-virtual -Wno-write-strings -Wno-error=maybe-uninitialized")
     set(CMAKE_CXX_FLAGS_DEBUG   "-O0 -g3")
     set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 endif()

--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -38,8 +38,6 @@ bool Check(Configuration& state) {
   }
 
   std::stringstream sql_statement;
-  size_t fragment_size = 4096;
-  char buffer[fragment_size];
 
   std::cout << "==================== Results ===================\n";
 
@@ -47,8 +45,8 @@ bool Check(Configuration& state) {
   while(!input->eof()){
 
     // Get a line from the input stream
-    input->getline(buffer, fragment_size);
-    std::string statement_fragment(buffer);
+    std::string statement_fragment;
+    std::getline(*input, statement_fragment);
 
     // Append fragment to statement
     if(statement_fragment.empty() == false){

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -793,7 +793,7 @@ void CheckSpaghettiQuery(Configuration& state,
                          const std::string& sql_statement,
                          bool& print_statement){
 
-  std::regex true_pattern(".+");
+  std::regex true_pattern(".+?");
   std::regex false_pattern("pattern must not exist");
   std::regex pattern;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -103,7 +103,7 @@ int main(int argc, char **argv) {
 
     // Parse the input arguments from the user
     gflags::SetUsageMessage("");
-    gflags::SetVersionString("1.2");
+    gflags::SetVersionString("1.2.1");
 
     gflags::ParseCommandLineFlags(&argc, &argv, true);
 


### PR DESCRIPTION
- Don't error on the possibly uninitialized variable.
- Use std::getline to read lines of arbitrary length
- Use lazy quantification for the spaghetti code regex to avoid segfault on what - I think - is a stack overflow
- Bump patch version to 1.2.1
