### PR TITLE
Update deprecated Ubuntu runner image

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -28,7 +28,7 @@ jobs:
           git submodule update --init --recursive \
           && ./bootstrap \
           && cd build \
-          && cmake -DCMAKE_BUILD_TYPE=RELEASE .. \
+          && cmake -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_POLICY_VERSION_MINIMUM=3.5 .. \
           && make \
           && sudo make install
 

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -13,7 +13,7 @@ jobs:
       SQLCHECK_PACKAGE_NAME: sqlcheck
       SQLCHECK_PACKAGE_VERSION: '1.2.1'
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Install dependencies


### PR DESCRIPTION
The Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01 and will be fully unsupported by 2025-04-01.

Learn more:

- https://github.com/actions/runner-images/issues/11101
- https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/
- https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/

https://bitsomx.atlassian.net/browse/DX-3277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the automated build and release process for improved performance and stability. These updates help ensure quicker and more reliable software updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->